### PR TITLE
Allow string argument in the BalenaReleaseNotFound constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,8 @@ throw new errors.BalenaInvalidDeviceType('raspberry-pi')
 <a name="new_module_errors..BalenaDiscontinuedDeviceType_new"></a>
 
 #### new BalenaDiscontinuedDeviceType(type)
-The device type that you specified is invalid because it isdiscontinued, and this operation is no longer supported.
+The device type that you specified is invalid because it is
+discontinued, and this operation is no longer supported.
 
 **Returns**: <code>Error</code> - error instance  
 
@@ -197,7 +198,7 @@ throw new errors.BalenaApplicationNotFound('MyApp')
 
 | Param | Type | Description |
 | --- | --- | --- |
-| release | <code>Number</code> | release id |
+| release | <code>String</code> \| <code>Number</code> | release commit or id |
 
 **Example**  
 ```js

--- a/lib/errors.ts
+++ b/lib/errors.ts
@@ -144,14 +144,14 @@ BalenaApplicationNotFound.prototype.code = 'BalenaApplicationNotFound';
  * @class
  * @public
  *
- * @param {(Number)} release - release id
+ * @param {(String|Number)} release - release commit or id
  * @return {Error} error instance
  *
  * @example
  * throw new errors.BalenaReleaseNotFound(123)
  */
 export class BalenaReleaseNotFound extends BalenaError {
-	constructor(public release: number) {
+	constructor(public release: string | number) {
 		super(`Release not found: ${release}`);
 	}
 }


### PR DESCRIPTION
The SDK has a method for retrieving a Release by
commit and the typings here block me from
converting it to TypeScript.

Change-type: minor
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>