### PR TITLE
Mark BalenaSupervisorLockedError token parameter as optional

### DIFF
--- a/lib/errors.ts
+++ b/lib/errors.ts
@@ -97,7 +97,7 @@ BalenaMalformedToken.prototype.code = 'BalenaMalformedToken';
  * throw new errors.BalenaSupervisorLockedError()
  */
 export class BalenaSupervisorLockedError extends BalenaError {
-	constructor(public token: string) {
+	constructor(public token?: string) {
 		super(`Supervisor locked`);
 	}
 }


### PR DESCRIPTION
Depends on #40 

This matches current usage in the wild