### PR TITLE
Add BalenaSettingsPermissionError

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ Documentation
         * [new BalenaDiscontinuedDeviceType(type)](#new_module_errors..BalenaDiscontinuedDeviceType_new)
     * [~BalenaMalformedToken](#module_errors..BalenaMalformedToken)
         * [new BalenaMalformedToken(token)](#new_module_errors..BalenaMalformedToken_new)
+    * [~BalenaSettingsPermissionError](#module_errors..BalenaSettingsPermissionError)
+        * [new BalenaSettingsPermissionError(error)](#new_module_errors..BalenaSettingsPermissionError_new)
     * [~BalenaSupervisorLockedError](#module_errors..BalenaSupervisorLockedError)
         * [new BalenaSupervisorLockedError(token)](#new_module_errors..BalenaSupervisorLockedError_new)
     * [~BalenaExpiredToken](#module_errors..BalenaExpiredToken)
@@ -159,6 +161,25 @@ throw new errors.BalenaDiscontinuedDeviceType('edge')
 **Example**  
 ```js
 throw new errors.BalenaMalformedToken('1234')
+```
+<a name="module_errors..BalenaSettingsPermissionError"></a>
+
+### errors~BalenaSettingsPermissionError
+**Kind**: inner class of [<code>errors</code>](#module_errors)  
+**Summary**: Balena settings permission error  
+**Access**: public  
+<a name="new_module_errors..BalenaSettingsPermissionError_new"></a>
+
+#### new BalenaSettingsPermissionError(error)
+**Returns**: <code>Error</code> - error instance  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| error | <code>Error</code> | usually an EACCESS error |
+
+**Example**  
+```js
+throw new errors.BalenaSettingsPermissionError()
 ```
 <a name="module_errors..BalenaSupervisorLockedError"></a>
 

--- a/lib/errors.ts
+++ b/lib/errors.ts
@@ -121,6 +121,20 @@ export class BalenaMalformedToken extends BalenaError {
 BalenaMalformedToken.prototype.code = 'BalenaMalformedToken';
 
 /**
+ * @summary Balena settings permission error
+ * @class
+ * @public
+ *
+ * @param {Error} error - usually an EACCESS error
+ * @return {Error} error instance
+ *
+ * @example
+ * throw new errors.BalenaSettingsPermissionError()
+ */
+export class BalenaSettingsPermissionError extends BalenaError {}
+BalenaSettingsPermissionError.prototype.code = 'BalenaSettingsPermissionError';
+
+/**
  * @summary The device supervisor is locked
  * @class
  * @public


### PR DESCRIPTION
This is error is to identify when there are permissions problems
related to the node js balena settings folder.

Related to https://github.com/balena-io/balena-cli/issues/1667

Change-type: minor