### PR TITLE
Disable source maps since they do not work

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,7 @@
     "noUnusedParameters": true,
     "preserveConstEnums": true,
     "pretty": true,
-    "sourceMap": true,
+    "sourceMap": false,
     "strictNullChecks": true,
     "lib": ["es5", "es6"],
     "declaration": true,


### PR DESCRIPTION
The emitted files atm include path:
`"sources":["../../lib/errors.ts"]`
which webpack can't load (and prints a warnings about) since we do not include the lib files in the package.

Change-type: patch
Signed-off-by: Andrea Rosci <andrear@balena.io>